### PR TITLE
modules/hebbot: Drop systemd working dir fix

### DIFF
--- a/modules/hebbot/default.nix
+++ b/modules/hebbot/default.nix
@@ -173,8 +173,4 @@ in
       report = ./templates/report.md;
     };
   };
-
-  systemd.services.hebbot.serviceConfig = {
-    WorkingDirectory = lib.mkForce "/var/lib/hebbot";
-  };
 }


### PR DESCRIPTION
This is now fixed in the upstream module.
