### PR TITLE
machines/narmora: nix.require-sigs = false

### DIFF
--- a/machines/narmora/configuration.nix
+++ b/machines/narmora/configuration.nix
@@ -9,6 +9,8 @@
     "admins"
   ];
 
+  nix.settings.require-sigs = false;
+
   imports = [
     ./disko.nix
     ./ssh.nix


### PR DESCRIPTION
Disable the `require-sigs` feature, for increased prototyping speed.
