### PR TITLE
pkgs/hebbot: Build from `inputs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,15 +75,16 @@
     "hebbot": {
       "flake": false,
       "locked": {
-        "lastModified": 1739049143,
-        "narHash": "sha256-Lz2fZQZIVywbKe9AGikYqJky78sb/OJqyDJcMka0Oec=",
-        "owner": "haecker-felix",
+        "lastModified": 1739531294,
+        "narHash": "sha256-dxmIsOIDN+i1MSHwuepvuziHPg12JotL3nM+MlTw4sE=",
+        "owner": "a-kenji",
         "repo": "hebbot",
-        "rev": "bd8bb7b5f3daf6926841007115324fb513b8476f",
+        "rev": "f4f0edfd2960a974467480ba15d6da3400548545",
         "type": "github"
       },
       "original": {
-        "owner": "haecker-felix",
+        "owner": "a-kenji",
+        "ref": "feat/publish",
         "repo": "hebbot",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     srvos.url = "github:nix-community/srvos?shallow=1";
     srvos.inputs.nixpkgs.follows = "nixpkgs";
 
-    hebbot.url = "github:haecker-felix/hebbot";
+    hebbot.url = "github:a-kenji/hebbot?ref=feat/publish";
     hebbot.flake = false;
 
     phaer-keys.url = "https://github.com/phaer.keys";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,4 +1,5 @@
-_: {
+{ inputs, ... }:
+{
   perSystem =
     {
       pkgs,
@@ -6,7 +7,7 @@ _: {
     }:
     {
       packages = {
-        hebbot = pkgs.callPackage ./packages/hebbot.nix { };
+        hebbot = pkgs.callPackage ./packages/hebbot.nix { inherit inputs; };
       };
     };
 }

--- a/nix/packages/hebbot.nix
+++ b/nix/packages/hebbot.nix
@@ -1,7 +1,6 @@
-# For now vendored from nixpkgs
 {
+  inputs,
   lib,
-  fetchFromGitHub,
   stdenv,
   rustPlatform,
   pkg-config,
@@ -10,7 +9,6 @@
   autoconf,
   automake,
   darwin,
-  unstableGitUpdater,
   sqlite,
 }:
 
@@ -18,19 +16,11 @@ rustPlatform.buildRustPackage rec {
   pname = "hebbot";
   version = "2.1-unstable-2024-09-20";
 
-  src = fetchFromGitHub {
-    owner = "a-kenji";
-    # owner = "haecker-felix";
-    repo = "hebbot";
-    rev = "f4f0edfd2960a974467480ba15d6da3400548545";
-    # hash = "sha256-y+KpxiEzVAggFoPvTOy0IEmAo2V6mOpM0VzEScUOtsM=";
-    hash = "sha256-dxmIsOIDN+i1MSHwuepvuziHPg12JotL3nM+MlTw4sE=";
-    # hash = lib.fakeHash;
-  };
+  src = inputs.hebbot;
+
+  cargoLock.lockFile = src + /Cargo.lock;
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-QrGM02rWX+mHQc7kEdCbq7x3Y5Y9IL+XQa4VvejH4KY=";
-  # cargoHash = lib.fakeHash;
 
   nativeBuildInputs =
     [
@@ -59,8 +49,6 @@ rustPlatform.buildRustPackage rec {
     "-L${lib.getLib openssl}/lib"
     "-L${lib.getLib sqlite}/lib"
   ];
-
-  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Matrix bot which can generate \"This Week in X\" like blog posts ";


### PR DESCRIPTION
Build `hebbot` package from `inputs` parameter, to simplify testing.
